### PR TITLE
expose server on HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 # ddev-solr <!-- omit in toc -->
 
-* [What is ddev-solr?](#what-is-ddev-solr)
-* [Solarium](#solarium)
-* [Drupal and Search API Solr](#drupal-and-search-api-solr)
+- [What is ddev-solr?](#what-is-ddev-solr)
+- [Solarium](#solarium)
+- [Drupal and Search API Solr](#drupal-and-search-api-solr)
+    - [Installation steps](#installation-steps)
 
 ## What is ddev-solr?
 
@@ -22,9 +23,9 @@ access rights:
 * password: `SolrRocks`
 
 Once up and running you can access Solr's UI within your browser by opening
-`http://<projectname>.ddev.site:8983`. For example, if the project is named
-"myproject" the hostname will be `http://myproject.ddev.site:8983`. To access
-the Solr container from the web container use `http://ddev-<project>-solr:8983`.
+`https://<projectname>.ddev.site:8983`. For example, if the project is named
+"myproject" the hostname will be `https://myproject.ddev.site:8983`. To access
+the Solr container from the web container use `https://ddev-<project>-solr:8983`.
 
 Solr Cloud depends on Zookeeper to share configurations between the Solr nodes.
 Therefore, this service starts a single Zookeeper server on port 2181, too.

--- a/docker-compose.solr.yaml
+++ b/docker-compose.solr.yaml
@@ -40,7 +40,8 @@ services:
       #SOLR_HEAP: 1g
       ZK_HOST: ddev-${DDEV_SITENAME}-zoo:2181
       VIRTUAL_HOST: $DDEV_HOSTNAME
-      HTTP_EXPOSE: 8983:8983
+      HTTP_EXPOSE: 8982:8983
+      HTTPS_EXPOSE: 8983:8983
     depends_on:
       - zoo
     volumes:

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -12,7 +12,7 @@ setup() {
 }
 
 health_checks() {
-  ddev exec "curl -u solr:SolrRocks -s http://ddev-${PROJNAME}-solr:8983/solr/# | grep Admin"
+  ddev exec "curl -u solr:SolrRocks -s https://ddev-${PROJNAME}-solr:8983/solr/# | grep Admin"
 }
 
 teardown() {
@@ -39,4 +39,3 @@ teardown() {
   ddev restart >/dev/null
   health_checks
 }
-


### PR DESCRIPTION
This PR moves the server to HTTPS.

## Problem

After running `ddev status`, I saw `http://solr-d10-demo.ddev.site:8983`, however click on this link opened the site in Chrome on HTTPS, which failed.